### PR TITLE
feat: add animated hello world component

### DIFF
--- a/src/hello-world.component.ts
+++ b/src/hello-world.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { trigger, style, transition, animate } from '@angular/animations';
+
+@Component({
+  selector: 'app-hello-world',
+  standalone: true,
+  template: `
+    <h2 @fadeIn>Hello World</h2>
+  `,
+  animations: [
+    trigger('fadeIn', [
+      transition(':enter', [
+        style({ opacity: 0 }),
+        animate('600ms ease-in', style({ opacity: 1 }))
+      ])
+    ])
+  ]
+})
+export class HelloWorldComponent {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,16 @@
 import 'zone.js';
 import {Component} from '@angular/core';
 import {bootstrapApplication} from '@angular/platform-browser';
+import {provideAnimations} from '@angular/platform-browser/animations';
+import {HelloWorldComponent} from './hello-world.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
+  imports: [HelloWorldComponent],
   template: `
     <h1>Hello from {{ name }}!</h1>
+    <app-hello-world></app-hello-world>
     <a target="_blank" href="https://angular.dev/overview">
       Learn more about Angulars
     </a>
@@ -16,4 +20,6 @@ export class App {
   name = 'Angular';
 }
 
-bootstrapApplication(App);
+bootstrapApplication(App, {
+  providers: [provideAnimations()]
+});


### PR DESCRIPTION
## Summary
- add standalone HelloWorldComponent with fade-in animation
- show animated component from root app and enable animations

## Testing
- `npm test -- --watch=false` *(fails: Schema validation failed with Data path `.polyfills` should be string)*
- `npm run lint` *(fails: unknown compiler option 'noImplicitOverride')*

------
https://chatgpt.com/codex/tasks/task_e_68ab843751f4832bbbdb6f7ff735aaaa