### PR TITLE
Add custom button tab header to mat-tab-group

### DIFF
--- a/src/global_styles.css
+++ b/src/global_styles.css
@@ -1,1 +1,2 @@
 /* Add application styles & imports to this file! */
+@import '@angular/material/prebuilt-themes/indigo-pink.css';

--- a/src/hello-world.component.html
+++ b/src/hello-world.component.html
@@ -1,33 +1,43 @@
-<div class="trial-wrapper">
-  <button class="trial-btn" (click)="triggerSparkle($event)">
-    <span class="badge">New</span>
-    <mat-icon class="timer" svgIcon="timer"></mat-icon>
-    <span>2-Hour Trial</span>
-    <mat-icon class="rocket" svgIcon="rocket"></mat-icon>
-
-    @if (sparkle) {
-      <span
-        class="sparkle-burst"
-        (animationend)="sparkle = false"
-        [style.--x.px]="sparkleX"
-        [style.--y.px]="sparkleY"
-      >
-        @for (_ of particles; track $index) {
-          <span class="spark"></span>
+<mat-tab-group>
+  <mat-tab>
+    <ng-template mat-tab-label>
+      <div class="trial-wrapper">
+        <button class="trial-btn" (click)="triggerSparkle($event)">
+          <span class="badge">New</span>
+          <mat-icon class="timer" svgIcon="timer"></mat-icon>
+          <span>2-Hour Trial</span>
+          <mat-icon class="rocket" svgIcon="rocket"></mat-icon>
+          @if (sparkle) {
+            <span
+              class="sparkle-burst"
+              (animationend)="sparkle = false"
+              [style.--x.px]="sparkleX"
+              [style.--y.px]="sparkleY"
+            >
+              @for (_ of particles; track $index) {
+                <span class="spark"></span>
+              }
+            </span>
+          }
+        </button>
+        @if (showTip) {
+          <div class="tooltip">
+            <div class="tip-header">Try it instantly</div>
+            Start a 2‑hour session in seconds — no license server required.
+            <div class="tip-footer">
+              <span class="hint">Click to begin</span>
+              <button (click)="dismissTip()">Dismiss</button>
+            </div>
+            <span class="tip-arrow"></span>
+          </div>
         }
-      </span>
-    }
-  </button>
-
-  @if (showTip) {
-    <div class="tooltip">
-      <div class="tip-header">Try it instantly</div>
-      Start a 2‑hour session in seconds — no license server required.
-      <div class="tip-footer">
-        <span class="hint">Click to begin</span>
-        <button (click)="dismissTip()">Dismiss</button>
       </div>
-      <span class="tip-arrow"></span>
-    </div>
-  }
-</div>
+    </ng-template>
+    <ng-template matTabContent>
+      Sample Content
+    </ng-template>
+  </mat-tab>
+  <mat-tab label="Second">
+    <p>Second tab content</p>
+  </mat-tab>
+</mat-tab-group>

--- a/src/hello-world.component.ts
+++ b/src/hello-world.component.ts
@@ -1,11 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 import { MatIconModule, MatIconRegistry } from '@angular/material/icon';
+import { MatTabsModule } from '@angular/material/tabs';
 import { DomSanitizer } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-hello-world',
   standalone: true,
-  imports: [MatIconModule],
+  imports: [MatIconModule, MatTabsModule],
   templateUrl: './hello-world.component.html',
   styleUrls: ['./hello-world.component.css']
 })


### PR DESCRIPTION
## Summary
- Import Angular Material tabs and theme to display components
- Create mat-tab-group with a button-based custom label on the first tab and dummy second tab

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Found 1 load error)*
- `npm run lint` *(fails: Cannot find builder "@angular-devkit/build-angular:tslint")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68acb2322f54832ba6fdedb6860a65b3