### PR TITLE
fix material icons by providing HttpClient

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import 'zone.js';
 import {Component} from '@angular/core';
 import {bootstrapApplication} from '@angular/platform-browser';
 import {HelloWorldComponent} from './hello-world.component';
+import {provideHttpClient} from '@angular/common/http';
 
 @Component({
   selector: 'app-root',
@@ -14,4 +15,6 @@ import {HelloWorldComponent} from './hello-world.component';
 export class App {
 }
 
-bootstrapApplication(App);
+bootstrapApplication(App, {
+  providers: [provideHttpClient()],
+});


### PR DESCRIPTION
## Summary
- provide HttpClient in bootstrap to support Angular Material icons

## Testing
- `npm test` (fails: No binary for Chrome browser)
- `npm run lint` (fails: Cannot find builder "@angular-devkit/build-angular:tslint")

------
https://chatgpt.com/codex/tasks/task_e_68acb3ee86e4832bad58344be3a187e4